### PR TITLE
cyberpunk-theme.el: Use :background to set the cursor color

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -114,7 +114,7 @@
 
    ;;; basic coloring
    `(default ((,class (:foreground ,cyberpunk-gray :background ,cyberpunk-black))))
-   `(cursor ((,class (:foreground ,cyberpunk-fg))))
+   `(cursor ((,class (:background ,cyberpunk-fg))))
    `(escape-glyph-face ((,class (:foreground ,cyberpunk-red))))
    ;; `(fringe ((,class (:foreground ,cyberpunk-fg :background ,cyberpunk-bg+1))))
    `(header-line ((,class (:foreground ,cyberpunk-yellow


### PR DESCRIPTION
In a cyberpunk buffer (frame-parameter (selected-frame) 'cursor-color)
is nil because frame-parameter checks against the :background parameter,
not the :foreground parameter.  This is a problem in auto-complete-mode
where the frame cursor color may be saved and restored.
