### PR TITLE
Mode-line fontification improvements

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -158,12 +158,12 @@
    `(mode-line
      ((,class (:foreground ,cyberpunk-blue-5
                            :background ,cyberpunk-gray-5
-                           :box (:line-width -1)))))
+                           :box (:line-width -1 :style released-button)))))
    ;; `(mode-line-buffer-id ((,class (:foreground ,cyberpunk-yellow :weight bold))))
    `(mode-line-inactive
      ((,class (:foreground ,cyberpunk-gray-7
                            :background ,cyberpunk-gray-6
-                           :box (:line-width -1)))))
+                           :box (:line-width -1 :style released-button)))))
    `(region ((,class (:background ,cyberpunk-red-5))))
    `(secondary-selection ((,class (:background ,cyberpunk-bg+2))))
    `(trailing-whitespace ((,class (:background ,cyberpunk-red))))


### PR DESCRIPTION
This commit changes how the mode-line is fontified. Previously, the fontification applied to the mode-line text was also applied to the top and bottom border of the mode-line. Now the fontification is applied only to the text - this seems to be closer to the intended behaviour.
