### PR TITLE
Set better color for linum-relative

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -443,6 +443,9 @@
    ;; linum-mode
    `(linum ((,class (:foreground ,cyberpunk-green+2 :background ,cyberpunk-bg))))
 
+   ;;linum-relative
+   `(linum-relative-current-face ((,class (:inherit linum :foreground ,cyberpunk-white :weight bold))))
+
    ;; magit
    `(magit-section-title ((,class (:foreground ,cyberpunk-pink-1))))
    `(magit-branch ((,class (:foreground ,cyberpunk-yellow-5))))


### PR DESCRIPTION
I edited the color of the current line number for the [linum-relative](https://github.com/coldnew/linum-relative) package.

*Before*:
![Image of linum-relative before]
(http://i.imgur.com/ae8hLdu.png)

*After*:
![Image of linum-relative after]
(http://i.imgur.com/b5dGGws.png)

