### PR TITLE
Match magit-diff faces with other diff faces in cyberpunk.

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -461,8 +461,7 @@
    `(magit-diff-removed                ((t (:foreground ,cyberpunk-magenta))))
    `(magit-diff-removed-highlight      ((t (:foreground ,cyberpunk-magenta :weight bold))))
    `(magit-diff-context                ((t (:foreground ,cyberpunk-gray))))
-   `(magit-diff-context-highlight      ((t (:background ,cyberpunk-bg+2
-                                            :foreground ,cyberpunk-gray))))
+   `(magit-diff-context-highlight      ((t (:foreground ,cyberpunk-gray :weight bold))))
    `(magit-diffstat-added   ((t (:foreground ,cyberpunk-blue-5))))
    `(magit-diffstat-removed ((t (:foreground ,cyberpunk-magenta))))
    ;; magit popup

--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -457,13 +457,13 @@
    `(magit-diff-lines-heading          ((t (:background ,cyberpunk-blue-6
                                             :foreground ,cyberpunk-bg+1))))
    `(magit-diff-added                  ((t (:foreground ,cyberpunk-blue-5))))
-   `(magit-diff-added-highlight        ((t (:foreground ,cyberpunk-blue-5 :weight bold))))
+   `(magit-diff-added-highlight        ((t (:inherit magit-diff-added :weight bold))))
    `(magit-diff-removed                ((t (:foreground ,cyberpunk-magenta))))
-   `(magit-diff-removed-highlight      ((t (:foreground ,cyberpunk-magenta :weight bold))))
+   `(magit-diff-removed-highlight      ((t (:inherit magit-diff-removed :weight bold))))
    `(magit-diff-context                ((t (:foreground ,cyberpunk-gray))))
-   `(magit-diff-context-highlight      ((t (:foreground ,cyberpunk-gray :weight bold))))
-   `(magit-diffstat-added   ((t (:foreground ,cyberpunk-blue-5))))
-   `(magit-diffstat-removed ((t (:foreground ,cyberpunk-magenta))))
+   `(magit-diff-context-highlight      ((t (:inherit magit-diff-context :weight bold))))
+   `(magit-diffstat-added   ((t (:inherit magit-diff-added))))
+   `(magit-diffstat-removed ((t (:inherit magit-diff-removed))))
    ;; magit popup
    `(magit-popup-heading             ((t (:foreground ,cyberpunk-pink-1  :weight bold))))
    `(magit-popup-key                 ((t (:foreground ,cyberpunk-blue+1 :weight bold))))

--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -419,7 +419,7 @@
    `(js2-jsdoc-tag-face ((,class (:foreground ,cyberpunk-green-1))))
    `(js2-jsdoc-type-face ((,class (:foreground ,cyberpunk-green+2))))
    `(js2-jsdoc-value-face ((,class (:foreground ,cyberpunk-green+3))))
-   `(js2-function-param-face ((,class (:foreground, cyberpunk-green+3))))
+   `(js2-function-param-face ((,class (:foreground ,cyberpunk-green+3))))
    `(js2-external-variable-face ((,class (:foreground ,cyberpunk-orange))))
 
    ;; jabber-mode

--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -456,6 +456,11 @@
                                             :foreground ,cyberpunk-blue-6))))
    `(magit-diff-lines-heading          ((t (:background ,cyberpunk-blue-6
                                             :foreground ,cyberpunk-bg+1))))
+   `(magit-diff-added                  ((t (:foreground ,cyberpunk-blue-5))))
+   `(magit-diff-added-highlight        ((t (:foreground ,cyberpunk-blue-5 :weight bold))))
+   `(magit-diff-removed                ((t (:foreground ,cyberpunk-magenta))))
+   `(magit-diff-removed-highlight      ((t (:foreground ,cyberpunk-magenta :weight bold))))
+   `(magit-diff-context                ((t (:foreground ,cyberpunk-gray))))
    `(magit-diff-context-highlight      ((t (:background ,cyberpunk-bg+2
                                             :foreground ,cyberpunk-gray))))
    `(magit-diffstat-added   ((t (:foreground ,cyberpunk-blue-5))))


### PR DESCRIPTION
This attempts to improve the consistency of `magit-diff-*` faces in the cyberpunk theme.

I didn't change the `diff-*` faces since they were different (but nice) from the rest of the cyberpunk theme.
