### PR TITLE
Add custom variable for transparent background

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -37,6 +37,9 @@
 
 (deftheme cyberpunk "The Cyberpunk color theme")
 
+(defcustom cyberpunk-transparent-background nil
+  "Make transparent background in terminal. (Workaround)")
+
 (let ((class '((class color) (min-colors 89)))
       ;; Cyberpunk palette
       (cyberpunk-fg "#dcdccc")
@@ -84,7 +87,9 @@
       (cyberpunk-blue-7 "#00ffff")
       (cyberpunk-blue-8 "#4F94CD")
       (cyberpunk-magenta "#dc8cc3")
-      (cyberpunk-black (if (and (not (display-graphic-p)) (eq system-type 'darwin))
+      (cyberpunk-black (if (and cyberpunk-transparent-background
+                                (not (display-graphic-p))
+                                (eq system-type 'darwin))
                            "ARGBBB000000"
                          "#000000"))
       (cyberpunk-black-2 "#0C1021")


### PR DESCRIPTION
When background color is "ARGBBB000000",
focus-mode(https://github.com/larstvei/Focus) insn't working.
Focus-mode check defined color by `color-defined-p`.