### PR TITLE
Added helm-ff-directory color to make it look better

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -409,6 +409,7 @@
    `(helm-selection-line ((,class (:background ,cyberpunk-bg+1))))
    `(helm-visible-mark ((,class (:foreground ,cyberpunk-bg :background ,cyberpunk-yellow-2))))
    `(helm-candidate-number ((,class (:foreground ,cyberpunk-green+4 :background ,cyberpunk-bg-1))))
+   `(helm-ff-directory ((,class (:foreground ,cyberpunk-pink :background ,cyberpunk-bg))))
 
    ;; hl-line-mode
    `(hl-sexp-face ((,class (:background ,cyberpunk-gray-5))))


### PR DESCRIPTION
In Helm, the default colors for directory name looked
ugly with pink text and gray background. I changed to 
only display it with the pink text.

### Before:
![emacsbefore](https://cloud.githubusercontent.com/assets/17310566/25629493/4b868504-2f87-11e7-9d41-6b2bbe665885.png)

### After:
![emacsafter](https://cloud.githubusercontent.com/assets/17310566/25629494/4b96e2e6-2f87-11e7-82c8-b384dc2d3af1.png)