### PR TITLE
Change org-column and org-column-title's background

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -153,7 +153,7 @@
    ;; faces used by isearch
    `(isearch ((,class (:foreground ,cyberpunk-black :background ,cyberpunk-pink-1))))
    `(isearch-fail ((,class (:background ,cyberpunk-red-1))))
-   
+
    `(lazy-highlight ((,class (:foreground ,cyberpunk-black :background ,cyberpunk-yellow))))
    `(query-replace ((,class (:background ,cyberpunk-gray-5))))
    `(Highline-face ((,class (:background ,cyberpunk-green-1))))
@@ -180,7 +180,7 @@
    ;;; font lock
    `(font-lock-builtin-face ((,class (:foreground ,cyberpunk-blue-5))))
    `(font-lock-comment-face ((,class (:foreground ,cyberpunk-gray-2 :italic t))))
-   ;; `(font-lock-comment-delimiter-face ((,class (:foreground ,cyberpunk-green)))) 
+   ;; `(font-lock-comment-delimiter-face ((,class (:foreground ,cyberpunk-green))))
    `(font-lock-constant-face ((,class (:foreground ,cyberpunk-blue-6))))
    ;; `(font-lock-doc-face ((,class (:foreground ,cyberpunk-green+1))))
    `(font-lock-doc-face ((,class (:foreground ,cyberpunk-yellow-1))))
@@ -259,7 +259,7 @@
    `(company-scrollbar-bg ((,class (:background ,cyberpunk-gray-5))))
    `(company-preview ((,class (:foreground ,cyberpunk-gray :background ,cyberpunk-pink-1))))
    `(company-preview-common ((,class (:foreground ,cyberpunk-gray :background ,cyberpunk-pink-1))))
-   
+
    ;; diff
    `(diff-added ((,class (:foreground ,cyberpunk-green))))
    `(diff-changed ((,class (:foreground ,cyberpunk-yellow))))
@@ -530,7 +530,7 @@
    `(magit-reflog-cherry-pick  ((t (:foreground ,cyberpunk-green))))
    `(magit-reflog-remote       ((t (:foreground ,cyberpunk-cyan))))
    `(magit-reflog-other        ((t (:foreground ,cyberpunk-cyan))))
-   
+
    `(eval-sexp-fu-flash ((,class (:background ,cyberpunk-gray-8 :foreground ,cyberpunk-pink-2))))
 
    ;; message-mode
@@ -620,13 +620,13 @@
    `(org-level-8 ((,class (:foreground ,cyberpunk-blue-1))))
    `(org-link ((,class (:foreground ,cyberpunk-blue-6 :underline t))))
    `(org-tag ((,class (:bold t :weight bold))))
-   `(org-column ((,class (:background ,cyberpunk-yellow-3 :foreground ,cyberpunk-black))))
-   `(org-column-title ((,class (:background ,cyberpunk-bg-1 :underline t :weight bold))))
+   `(org-column ((,class (:background ,cyberpunk-gray-7 :foreground ,cyberpunk-black))))
+   `(org-column-title ((,class (:background ,cyberpunk-gray-7 :underline t :weight bold))))
    `(org-block ((,class (:foreground ,cyberpunk-fg :background ,cyberpunk-bg-05))))
-   `(org-block-begin-line 
+   `(org-block-begin-line
      ((,class (:foreground "#008ED1" :background ,cyberpunk-bg-1))))
    `(org-block-background ((,class (:background ,cyberpunk-bg-05))))
-   `(org-block-end-line 
+   `(org-block-end-line
      ((,class (:foreground "#008ED1" :background ,cyberpunk-bg-1))))
 
    ;; `(org-deadline-announce ((,class (:foreground ,cyberpunk-red-1))))


### PR DESCRIPTION
The origin background is yellow, whick let org-agenda's ITEM hardly to read. so I change it to cyberpunk-gray-7
![default](https://user-images.githubusercontent.com/67725/39463517-014948cc-4d4b-11e8-84b2-2e58b43c5a0f.png)
