### PR TITLE
 Do not set org-level-*'s height 

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -610,9 +610,9 @@
                               :box (:line-width 1 :style none)))))
    `(org-todo ((,class (:bold t :foreground ,cyberpunk-orange :weight bold
                               :box (:line-width 1 :style none)))))
-   `(org-level-1 ((,class (:foreground ,cyberpunk-pink-1 :height 1.3))))
-   `(org-level-2 ((,class (:foreground ,cyberpunk-yellow :height 1.2))))
-   `(org-level-3 ((,class (:foreground ,cyberpunk-blue-5 :height 1.1))))
+   `(org-level-1 ((,class (:foreground ,cyberpunk-pink-1))))
+   `(org-level-2 ((,class (:foreground ,cyberpunk-yellow))))
+   `(org-level-3 ((,class (:foreground ,cyberpunk-blue-5))))
    `(org-level-4 ((,class (:foreground ,cyberpunk-green))))
    `(org-level-5 ((,class (:foreground ,cyberpunk-orange))))
    `(org-level-6 ((,class (:foreground ,cyberpunk-pink))))

--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -106,7 +106,7 @@
       (cyberpunk-white-2 "#F8F8F8")
       (cyberpunk-white-3 "#fffafa"))
 
- (custom-theme-set-faces
+  (custom-theme-set-faces
    'cyberpunk
    '(button ((t (:underline t))))
    `(link ((,class (:foreground ,cyberpunk-yellow :underline t :weight bold))))
@@ -458,13 +458,13 @@
    `(magit-diff-file-heading           ((t (:weight bold))))
    `(magit-diff-file-heading-highlight ((t (:background ,cyberpunk-bg+2  :weight bold))))
    `(magit-diff-file-heading-selection ((t (:background ,cyberpunk-bg+2
-                                            :foreground ,cyberpunk-blue-6 :weight bold))))
+                                                        :foreground ,cyberpunk-blue-6 :weight bold))))
    `(magit-diff-hunk-heading           ((t (:background ,cyberpunk-bg))))
    `(magit-diff-hunk-heading-highlight ((t (:background ,cyberpunk-bg+1))))
    `(magit-diff-hunk-heading-selection ((t (:background ,cyberpunk-bg+1
-                                            :foreground ,cyberpunk-blue-6))))
+                                                        :foreground ,cyberpunk-blue-6))))
    `(magit-diff-lines-heading          ((t (:background ,cyberpunk-blue-6
-                                            :foreground ,cyberpunk-bg+1))))
+                                                        :foreground ,cyberpunk-bg+1))))
    `(magit-diff-added                  ((t (:foreground ,cyberpunk-blue-5))))
    `(magit-diff-added-highlight        ((t (:inherit magit-diff-added :weight bold))))
    `(magit-diff-removed                ((t (:foreground ,cyberpunk-magenta))))
@@ -604,7 +604,7 @@
      ((,class (:inherit font-lock-comment-face))))
    `(org-archived ((,class (:slant italic))))
    `(org-checkbox ((,class (:background ,cyberpunk-gray-2 :foreground ,cyberpunk-black
-                                   :box (:line-width 1 :style released-button)))))
+                                        :box (:line-width 1 :style released-button)))))
    `(org-date ((,class (:foreground ,cyberpunk-blue-7 :underline t))))
    `(org-done ((,class (:bold t :weight bold :foreground ,cyberpunk-green
                               :box (:line-width 1 :style none)))))
@@ -789,7 +789,7 @@
    `(wl-highlight-message-unimportant-header-contents ((,class (:foreground ,cyberpunk-fg))))
    `(wl-highlight-summary-answered-face ((,class (:foreground ,cyberpunk-blue))))
    `(wl-highlight-summary-disposed-face ((,class (:foreground ,cyberpunk-fg
-                                                         :slant italic))))
+                                                              :slant italic))))
    `(wl-highlight-summary-new-face ((,class (:foreground ,cyberpunk-blue))))
    `(wl-highlight-summary-normal-face ((,class (:foreground ,cyberpunk-fg))))
    `(wl-highlight-summary-thread-top-face ((,class (:foreground ,cyberpunk-yellow))))
@@ -818,7 +818,7 @@
   (custom-theme-set-variables
    'cyberpunk
    `(ansi-color-names-vector [,cyberpunk-bg ,cyberpunk-red-2 ,cyberpunk-green ,cyberpunk-orange
-                                          ,cyberpunk-blue-1 ,cyberpunk-magenta ,cyberpunk-cyan ,cyberpunk-fg])
+                                            ,cyberpunk-blue-1 ,cyberpunk-magenta ,cyberpunk-cyan ,cyberpunk-fg])
    ;; fill-column-indicator
    `(fci-rule-color ,cyberpunk-bg-05)))
 


### PR DESCRIPTION
Many like set level-1's height 1.3 and  level-2 1.1, this looks beautiful, but which
let tags not align properly, for example:

![default](https://user-images.githubusercontent.com/67725/39728699-dacf2032-528a-11e8-9892-d61e1b19d237.png)

new:

![default](https://user-images.githubusercontent.com/67725/39728713-f0d5dd26-528a-11e8-87b3-dca7721dcbbc.png)
