### PR TITLE
Various tweaks

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -818,6 +818,9 @@
    `(custom-button ((,class (:box (:line-width 2 :style released-button)
                                   :background ,cyberpunk-bg-05 :foreground ,cyberpunk-fg))))
    `(custom-button-unraised ((,class (:background ,cyberpunk-bg-05 :foreground ,cyberpunk-fg))))
+
+   ;; info
+   `(Info-quoted ((,class (:inherit fixed-pitch-serif :foreground ,cyberpunk-pink))))
    )
 
   ;;; custom theme variables

--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -832,6 +832,9 @@
    ;; dired+
    `(diredp-symlink ((,class (:foreground ,cyberpunk-pink))))
    `(diredp-compressed-file-suffix ((,class (:foreground ,cyberpunk-blue-1))))
+
+   ;; ivy
+   `(ivy-current-match ((,class (:box (:line-width 3 :color ,cyberpunk-magenta :style pressed-button) :weight bold))))
    )
 
   ;;; custom theme variables

--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -821,6 +821,13 @@
 
    ;; info
    `(Info-quoted ((,class (:inherit fixed-pitch-serif :foreground ,cyberpunk-pink))))
+
+   ;; dired
+   `(dired-symlink-face ((,class (:foreground ,cyberpunk-pink))))
+
+   ;; dired+
+   `(diredp-symlink ((,class (:foreground ,cyberpunk-pink))))
+   `(diredp-compressed-file-suffix ((,class (:foreground ,cyberpunk-blue-1))))
    )
 
   ;;; custom theme variables

--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -749,8 +749,12 @@
                                            :background ,cyberpunk-blue))))
    `(term-color-white ((,class (:foreground ,cyberpunk-fg
                                             :background ,cyberpunk-bg-1))))
+   ;; term-default-fg-color & term-default-bg-color are obsolete, kept
+   ;; here for compatibility reasons.
    `(term-default-fg-color ((,class (:inherit term-color-white))))
    `(term-default-bg-color ((,class (:inherit term-color-black))))
+   ;; Used in 24.3 and later to replace above.
+   `(term ((,class (:foreground ,cyberpunk-fg :background ,cyberpunk-bg))))
 
    ;; volatile-highlights
    `(vhl/default-face ((,class (:background ,cyberpunk-gray-5))))


### PR DESCRIPTION
*Excuse the visual artifacts in the screenshot window decorations / minibuffer gutter.*

I had a bunch of detritus in my `custom-set-faces` that kept getting in the way when switching between themes with color palettes different than cyberpunk's, so I figure I'd open a PR and see what everybody thinks. :)

# Colorize Info-quoted

Used in keyboard shortcuts and some identifiers/syntax in infopages. Makes it very easy to separate the code/keyboard shortcuts from the prose.

I usually remove the `:inherit fixed-pitch-serif` in my customize, but I think this should be left up to the user.

## Before

![old-info-quoted](https://user-images.githubusercontent.com/3893828/71337919-53472800-2513-11ea-93fe-d529a97f46af.png)

## After

![new-info-quoted](https://user-images.githubusercontent.com/3893828/71337935-5e9a5380-2513-11ea-93ae-681c47be9eb0.png)


# Tweak dired/dired+ symlink colors

## Before

![old-symlink](https://user-images.githubusercontent.com/3893828/71337738-84732880-2512-11ea-8f5a-811cd83fe4a4.png)

## After

![new-symlink](https://user-images.githubusercontent.com/3893828/71337753-8f2dbd80-2512-11ea-990c-6497509b6444.png)

# Fix dired+ compressed suffix color

Previously it was a bit too dark.

## Before

![old-compressed-suffix](https://user-images.githubusercontent.com/3893828/71337795-b1274000-2512-11ea-912e-c86e0526858d.png)


## After

![new-compressed-suffix](https://user-images.githubusercontent.com/3893828/71337805-b7b5b780-2512-11ea-832d-aa3ce666890a.png)


# Fix ansi-term/term default color

## Before

![without-ansi-term-fix](https://user-images.githubusercontent.com/3893828/71337653-2b0af980-2512-11ea-96f0-e902554f8614.png)

## After
![ansi-term-fix](https://user-images.githubusercontent.com/3893828/71337670-3cec9c80-2512-11ea-922b-09f60807e17e.png)


# Ivy tweak

Makes ivy match candidate very clear. It is particularly difficult to determine what is the best candidate when there are multiple matches with the same prefix or suffix.

## Before

![old-ivy](https://user-images.githubusercontent.com/3893828/71337563-dc5d5f80-2511-11ea-8c1b-2176bdd72f3b.gif)

## After

![new-ivy](https://user-images.githubusercontent.com/3893828/71337572-e41d0400-2511-11ea-9b66-5a61c824c9d3.gif)
