### PR TITLE
org-{todo,done}: use nil instead none

### DIFF
--- a/cyberpunk-theme.el
+++ b/cyberpunk-theme.el
@@ -609,9 +609,9 @@
                                         :box (:line-width 1 :style released-button)))))
    `(org-date ((,class (:foreground ,cyberpunk-blue-7 :underline t))))
    `(org-done ((,class (:bold t :weight bold :foreground ,cyberpunk-green
-                              :box (:line-width 1 :style none)))))
+                              :box (:line-width 1 :style nil)))))
    `(org-todo ((,class (:bold t :foreground ,cyberpunk-orange :weight bold
-                              :box (:line-width 1 :style none)))))
+                              :box (:line-width 1 :style nil)))))
    `(org-level-1 ((,class (:foreground ,cyberpunk-pink-1))))
    `(org-level-2 ((,class (:foreground ,cyberpunk-yellow))))
    `(org-level-3 ((,class (:foreground ,cyberpunk-blue-5))))


### PR DESCRIPTION
Changing none to nil for org-todo and org-done faces enabled me to continue using this esteemed theme with an Emacs built this morning from the development branch.

It appears backward compatible at least in so far as the theme still loads without complaint on older Emacs (e.g. 29.1 and also a less recent Emacs 30, that I have tried).